### PR TITLE
Set SSL hostname

### DIFF
--- a/htpdate.c
+++ b/htpdate.c
@@ -354,6 +354,7 @@ static double getHTTPdate(
     SSL_CTX_set_verify_depth(tls_ctx, 4);
     if (verifycert) SSL_CTX_set_verify(tls_ctx, SSL_VERIFY_PEER, NULL);
     SSL *conn = SSL_new(tls_ctx);
+    SSL_set_tlsext_host_name(conn, host);
     if (scheme) {
         if (proxy) {
             rc = proxyCONNECT(server_s, host, port, proxy, proxyport, httpversion);


### PR DESCRIPTION
https://ambient-ai.atlassian.net/browse/AMB-11097

Some firewalls / transparent proxies require the server hostname to be set during TLS negotiation, or the connection will fail. This is the case at ebay for example.

This change sets the hostname on the SSL object using https://www.openssl.org/docs/man1.1.1/man3/SSL_set_tlsext_host_name.html

Tested on ebay-vault